### PR TITLE
Change repository URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![status](https://img.shields.io/pypi/status/cloudscale.svg)
 [![pypi version](https://img.shields.io/pypi/v/cloudscale.svg)](https://pypi.org/project/cloudscale/)
 ![PyPI - Downloads](https://img.shields.io/pypi/dw/cloudscale)
-[![codecov](https://codecov.io/gh/resmo/python-cloudscale/branch/master/graph/badge.svg)](https://codecov.io/gh/resmo/python-cloudscale)
+[![codecov](https://codecov.io/gh/cloudscale-ch/python-cloudscale/branch/master/graph/badge.svg)](https://codecov.io/gh/resmo/python-cloudscale)
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     description="A library and command line interface for cloudscale.ch",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/resmo/python-cloudscale",
+    url="https://github.com/cloudscale-ch/python-cloudscale",
     packages=find_packages(exclude=["test.*", "tests"]),
     classifiers=[
         "Intended Audience :: Developers",


### PR DESCRIPTION
The repository moved to the cloudscale-ch Github organization.