### PR TITLE
consolidate options to global options

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ cloudscale-cli flavor list
 Passing the `--api-token` parameter:
 
 ~~~shell
-cloudscale-cli server --api-token <your_token> create ...
+cloudscale-cli --api-token <your_token> server create ...
 ~~~
 
 #### Config file
@@ -77,7 +77,7 @@ api_token = <token>
 
 Passing the command line option will overwrite the ENV var as one would expect:
 ~~~
-cloudscale-cli server --profile production list
+cloudscale-cli --profile production server list
 ~~~
 
 ## Help
@@ -89,7 +89,12 @@ See all options:
 Usage: cloudscale-cli [OPTIONS] COMMAND [ARGS]...
 
 Options:
-  -h, --help  Show this message and exit.
+  --version                  Show the version and exit.
+  -a, --api-token TEXT       API token.
+  -p, --profile TEXT         Profile used in config file.
+  -v, --verbose              Enables verbose mode.
+  -o, --output [table|json]  Output format.  [default: table]
+  -h, --help                 Show this message and exit.
 
 Commands:
   flavor
@@ -101,7 +106,6 @@ Commands:
   server
   server-group
   subnet
-  version
   volume
 ~~~
 
@@ -115,8 +119,16 @@ cloudscale-cli server create --flavor flex-2 --name my-server --image centos-7 -
 
 #### List all servers
 
+Get a list as table view:
+
 ~~~shell
 cloudscale-cli server list
+~~~
+
+Get a list as JSON response:
+
+~~~shell
+cloudscale-cli -o json server list
 ~~~
 
 #### List servers having the tag project with value gemini
@@ -159,6 +171,20 @@ cloudscale-cli server stop <uuid>
 
 ~~~shell
 cloudscale-cli server start <uuid>
+~~~
+
+#### Delete a server
+
+Query and prompt to delete a server:
+
+~~~shell
+cloudscale-cli server delete <uuid>
+~~~
+
+Just delete without questions asked:
+
+~~~shell
+cloudscale-cli server delete -f <uuid>
 ~~~
 
 ## Usage in Python

--- a/cloudscale/cli.py
+++ b/cloudscale/cli.py
@@ -1,6 +1,7 @@
 import click
+from .version import __version__
 from .util import OrderedGroup
-from .commands.version import cmd_version
+from .commands import CloudscaleCommand, OUTPUT_FORMATS
 from .commands.server import server
 from .commands.server_group import server_group
 from .commands.flavor import flavor
@@ -16,11 +17,21 @@ from .commands.objects_user import objects_user
 @click.group(cls=OrderedGroup, context_settings={
     'help_option_names': ['-h', '--help'],
 })
-def cli():
-    pass
+@click.version_option(__version__, '--version')
+@click.option('--api-token', '-a', envvar='CLOUDSCALE_API_TOKEN', help="API token.")
+@click.option('--profile', '-p', envvar='CLOUDSCALE_PROFILE', help="Profile used in config file.")
+@click.option('--verbose', '-v', is_flag=True, help='Enables verbose mode.')
+@click.option('--output', '-o', type=click.Choice(OUTPUT_FORMATS), default="table", help="Output format.", show_default=True)
+@click.pass_context
+def cli(ctx, profile, api_token, verbose, output):
+    ctx.obj = CloudscaleCommand(
+        api_token=api_token,
+        profile=profile,
+        verbose=verbose,
+        output=output,
+    )
 
 
-cli.add_command(cmd_version)
 cli.add_command(server)
 cli.add_command(server_group)
 cli.add_command(floating_ip)

--- a/cloudscale/commands/__init__.py
+++ b/cloudscale/commands/__init__.py
@@ -3,91 +3,116 @@ import click
 from ..util import to_table, to_pretty_json, tags_to_dict
 from .. import Cloudscale, CloudscaleApiException, CloudscaleException
 
-def _init(ctx, api_token, profile, verbose):
-    try:
-        ctx.obj = Cloudscale(api_token, profile, verbose)
-    except CloudscaleException as e:
-        click.echo(e, err=True)
-        sys.exit(1)
+OUTPUT_FORMATS = [
+    'table',
+    'json',
+]
 
-def _list(resource, headers, filter_tag=None):
-    try:
-        response = resource.get_all(filter_tag)
-        if response:
-            table = to_table(response, headers)
-            click.echo(table)
-    except CloudscaleApiException as e:
-        click.echo(e, err=True)
-        sys.exit(1)
+class CloudscaleCommand:
 
-def _show(resource, uuid):
-    try:
-        response = resource.get_by_uuid(uuid)
-        click.echo(to_pretty_json(response))
-    except CloudscaleApiException as e:
-        click.echo(e, err=True)
-        sys.exit(1)
+    def __init__(self, cloud_resource_name=None, api_token=None, profile=None, verbose=False, output="table", headers=[]):
+        try:
+            self._client = Cloudscale(
+                api_token=api_token,
+                profile=profile,
+                verbose=verbose
+            )
+        except CloudscaleException as e:
+            click.echo(e, err=True)
+            sys.exit(1)
 
-def _create(resource, **kwargs):
-    try:
-        if 'tags' in kwargs:
-            try:
-                kwargs['tags'] = tags_to_dict(kwargs['tags'])
-            except ValueError as e:
-                click.echo(e, err=True)
-                sys.exit(1)
+        self._output = output
 
-        response = resource.create(**kwargs)
-        click.echo(to_pretty_json(response))
-    except CloudscaleApiException as e:
-        click.echo(e, err=True)
-        sys.exit(1)
+        self.cloud_resource_name = cloud_resource_name
+        self.headers = headers
 
-def _update(resource, uuid, tags, clear_tags, clear_all_tags, **kwargs):
-    try:
-        _tags = dict()
-        if not clear_all_tags:
-            response = resource.get_by_uuid(uuid=uuid)
-            _tags = response.get('tags', dict()).copy()
+    def get_client_resource(self):
+        return getattr(self._client, self.cloud_resource_name)
 
-            for k in clear_tags:
-                _tags.pop(k, None)
+    def _format_output(self, response):
+        if self._output == "json":
+            return to_pretty_json(response)
+        else:
+            if isinstance(response, dict):
+                response = [response]
+            return to_table(response, self.headers)
 
-        if tags:
-            try:
-                _tags.update(tags_to_dict(tags))
-            except ValueError as e:
-                click.echo(e, err=True)
-                sys.exit(1)
+    def cmd_list(self, filter_tag=None):
+        try:
+            response = self.get_client_resource().get_all(filter_tag)
+            click.echo(self._format_output(response))
+        except CloudscaleApiException as e:
+            click.echo(e, err=True)
+            sys.exit(1)
 
-        resource.update(
-            uuid=uuid,
-            tags=_tags,
-            **kwargs,
-        )
-        response = resource.get_by_uuid(uuid=uuid)
-        click.echo(to_pretty_json(response))
-    except CloudscaleApiException as e:
-        click.echo(e, err=True)
-        sys.exit(1)
+    def cmd_show(self, uuid):
+        try:
+            response = self.get_client_resource().get_by_uuid(uuid)
+            click.echo(self._format_output(response))
+        except CloudscaleApiException as e:
+            click.echo(e, err=True)
+            sys.exit(1)
 
-def _delete(resource, uuid, headers, force):
-    try:
-        response = resource.get_by_uuid(uuid)
-        table = to_table([response], headers)
-        click.echo(table)
-        if not force:
-            click.confirm('Do you want to delete?', abort=True)
-        resource.delete(uuid)
-        click.echo("Deleted!")
-    except CloudscaleApiException as e:
-        click.echo(e, err=True)
-        sys.exit(1)
+    def cmd_create(self, **kwargs):
+        try:
+            if 'tags' in kwargs:
+                try:
+                    kwargs['tags'] = tags_to_dict(kwargs['tags'])
+                except ValueError as e:
+                    click.echo(e, err=True)
+                    sys.exit(1)
 
-def _act(resource, action, uuid):
-    try:
-        response = getattr(resource, action)(uuid)
-        click.echo(to_pretty_json(response))
-    except CloudscaleApiException as e:
-        click.echo(e, err=True)
-        sys.exit(1)
+            response = self.get_client_resource().create(**kwargs)
+            click.echo(self._format_output(response))
+        except CloudscaleApiException as e:
+            click.echo(e, err=True)
+            sys.exit(1)
+
+    def cmd_update(self, uuid, tags, clear_tags, clear_all_tags, **kwargs):
+        try:
+            _tags = dict()
+            if not clear_all_tags:
+                response = self.get_client_resource().get_by_uuid(uuid=uuid)
+                _tags = response.get('tags', dict()).copy()
+
+                for k in clear_tags:
+                    _tags.pop(k, None)
+
+            if tags:
+                try:
+                    _tags.update(tags_to_dict(tags))
+                except ValueError as e:
+                    click.echo(e, err=True)
+                    sys.exit(1)
+
+            self.get_client_resource().update(
+                uuid=uuid,
+                tags=_tags,
+                **kwargs,
+            )
+            response = self.get_client_resource().get_by_uuid(uuid=uuid)
+            click.echo(self._format_output(response))
+        except CloudscaleApiException as e:
+            click.echo(e, err=True)
+            sys.exit(1)
+
+    def cmd_delete(self, uuid, force):
+        try:
+            response = self.get_client_resource().get_by_uuid(uuid)
+            click.echo(self._format_output(response))
+            if not force:
+                click.confirm('Do you want to delete?', abort=True)
+            self.get_client_resource().delete(uuid)
+            click.echo("Deleted!")
+        except CloudscaleApiException as e:
+            click.echo(e, err=True)
+            sys.exit(1)
+
+    def cmd_act(self, action, uuid):
+        try:
+            getattr(self.get_client_resource(), action)(uuid)
+            response = self.get_client_resource().get_by_uuid(uuid)
+            click.echo(self._format_output(response))
+        except CloudscaleApiException as e:
+            click.echo(e, err=True)
+            sys.exit(1)

--- a/cloudscale/commands/flavor.py
+++ b/cloudscale/commands/flavor.py
@@ -1,26 +1,18 @@
 import click
-from . import _init, _list
-
-headers = ['name', 'vcpu_count', 'memory_gb', 'slug', 'zones']
 
 @click.group()
-@click.option('--api-token', '-a', envvar='CLOUDSCALE_API_TOKEN', help="API token.")
-@click.option('--profile', '-p', envvar='CLOUDSCALE_PROFILE', help="Profile used in config file.")
-@click.option('--verbose', '-v', is_flag=True, help='Enables verbose mode.')
 @click.pass_context
-def flavor(ctx, profile, api_token, verbose):
-    _init(
-        ctx=ctx,
-        api_token=api_token,
-        profile=profile,
-        verbose=verbose,
-    )
+def flavor(ctx):
+    ctx.obj.cloud_resource_name = "flavor"
+    ctx.obj.headers = [
+        'name',
+        'vcpu_count',
+        'memory_gb',
+        'slug',
+        'zones',
+    ]
 
 @flavor.command("list")
 @click.pass_obj
 def cmd_list(cloudscale):
-    resource = cloudscale.flavor
-    _list(
-        resource=resource,
-        headers=headers,
-    )
+    cloudscale.cmd_list()

--- a/cloudscale/commands/floating_ip.py
+++ b/cloudscale/commands/floating_ip.py
@@ -1,45 +1,38 @@
 import click
-from . import _init, _list, _show, _create, _update, _delete
-
-headers = ['network', 'ip_version', 'server', 'reverse_ptr', 'type', 'region', 'tags']
 
 @click.group()
-@click.option('--api-token', '-a', envvar='CLOUDSCALE_API_TOKEN', help="API token.")
-@click.option('--profile', '-p', envvar='CLOUDSCALE_PROFILE', help="Profile used in config file.")
-@click.option('--verbose', '-v', is_flag=True, help='Enables verbose mode.')
 @click.pass_context
-def floating_ip(ctx, profile, api_token, verbose):
-    _init(
-        ctx=ctx,
-        api_token=api_token,
-        profile=profile,
-        verbose=verbose,
-    )
+def floating_ip(ctx):
+    ctx.obj.cloud_resource_name = "floating_ip"
+    ctx.obj.headers = [
+        'network',
+        'ip_version',
+        'server',
+        'reverse_ptr',
+        'type',
+        'region',
+        'tags',
+    ]
 
 @click.option('--filter-tag')
 @floating_ip.command("list")
 @click.pass_obj
 def cmd_list(cloudscale, filter_tag):
-    resource = cloudscale.floating_ip
-    _list(
-        resource=resource,
-        headers=headers,
-        filter_tag=filter_tag,
+    cloudscale.cmd_list(
+        filter_tag=filter_tag
     )
 
 @click.argument('network-id', required=True)
 @floating_ip.command("show")
 @click.pass_obj
 def cmd_show(cloudscale, network_id):
-    resource = cloudscale.floating_ip
-    _show(
-        resource=resource,
+    cloudscale.cmd_show(
         uuid=network_id,
     )
 
 @click.option('--ip-version', type=int, default=4, show_default=True)
 @click.option('--server-uuid', '--server', required=True)
-@click.option('--prefix-length', type=int, show_default=True)
+@click.option('--prefix-length', type=int)
 @click.option('--reverse-ptr')
 @click.option('--type', 'scope', type=click.Choice(['regional', 'global']), default='regional', show_default=True)
 @click.option('--region')
@@ -53,9 +46,7 @@ def cmd_create(cloudscale, ip_version, server_uuid, prefix_length, reverse_ptr, 
         else:
             prefix_length = 32
 
-    resource = cloudscale.floating_ip
-    _create(
-        resource=resource,
+    cloudscale.cmd_create(
         ip_version=ip_version,
         server_uuid=server_uuid,
         prefix_length=prefix_length,
@@ -74,9 +65,7 @@ def cmd_create(cloudscale, ip_version, server_uuid, prefix_length, reverse_ptr, 
 @floating_ip.command("update")
 @click.pass_obj
 def cmd_update(cloudscale, network_id, server_uuid, reverse_ptr, tags, clear_tags, clear_all_tags):
-    resource = cloudscale.floating_ip
-    _update(
-        resource=resource,
+    cloudscale.cmd_update(
         uuid=network_id,
         tags=tags,
         clear_tags=clear_tags,
@@ -90,10 +79,7 @@ def cmd_update(cloudscale, network_id, server_uuid, reverse_ptr, tags, clear_tag
 @floating_ip.command("delete")
 @click.pass_obj
 def cmd_delete(cloudscale, network_id, force):
-    resource = cloudscale.floating_ip
-    _delete(
-        resource=resource,
+    cloudscale.cmd_delete(
         uuid=network_id,
-        headers=headers,
         force=force,
     )

--- a/cloudscale/commands/image.py
+++ b/cloudscale/commands/image.py
@@ -1,26 +1,17 @@
 import click
-from . import _init, _list
-
-headers = ['name', 'operating_system', 'default_username', 'slug']
 
 @click.group()
-@click.option('--api-token', '-a', envvar='CLOUDSCALE_API_TOKEN', help="API token.")
-@click.option('--profile', '-p', envvar='CLOUDSCALE_PROFILE', help="Profile used in config file.")
-@click.option('--verbose', '-v', is_flag=True, help='Enables verbose mode.')
 @click.pass_context
-def image(ctx, profile, api_token, verbose):
-    _init(
-        ctx=ctx,
-        api_token=api_token,
-        profile=profile,
-        verbose=verbose,
-    )
+def image(ctx):
+    ctx.obj.cloud_resource_name = "image"
+    ctx.obj.headers = [
+        'name',
+        'operating_system',
+        'default_username',
+        'slug',
+    ]
 
 @image.command("list")
 @click.pass_obj
 def cmd_list(cloudscale):
-    resource = cloudscale.image
-    _list(
-        resource=resource,
-        headers=headers,
-    )
+    cloudscale.cmd_list()

--- a/cloudscale/commands/network.py
+++ b/cloudscale/commands/network.py
@@ -1,29 +1,22 @@
 import click
-from . import _init, _list, _show, _create, _update, _delete
-
-headers = ['name', 'created_at', 'zone', 'tags', 'uuid']
 
 @click.group()
-@click.option('--api-token', '-a', envvar='CLOUDSCALE_API_TOKEN', help="API token.")
-@click.option('--profile', '-p', envvar='CLOUDSCALE_PROFILE', help="Profile used in config file.")
-@click.option('--verbose', '-v', is_flag=True, help='Enables verbose mode.')
 @click.pass_context
-def network(ctx, profile, api_token, verbose):
-    _init(
-        ctx=ctx,
-        api_token=api_token,
-        profile=profile,
-        verbose=verbose,
-    )
+def network(ctx):
+    ctx.obj.cloud_resource_name = "network"
+    ctx.obj.headers = [
+        'name',
+        'created_at',
+        'zone',
+        'tags',
+        'uuid',
+    ]
 
 @click.option('--filter-tag')
 @network.command("list")
 @click.pass_obj
 def cmd_list(cloudscale, filter_tag):
-    resource = cloudscale.network
-    _list(
-        resource=resource,
-        headers=headers,
+    cloudscale.cmd_list(
         filter_tag=filter_tag,
     )
 
@@ -31,9 +24,7 @@ def cmd_list(cloudscale, filter_tag):
 @network.command("show")
 @click.pass_obj
 def cmd_show(cloudscale, uuid):
-    resource = cloudscale.network
-    _show(
-        resource=resource,
+    cloudscale.cmd_show(
         uuid=uuid,
     )
 
@@ -45,15 +36,13 @@ def cmd_show(cloudscale, uuid):
 @network.command("create")
 @click.pass_obj
 def cmd_create(cloudscale, name, zone, mtu, auto_create_ipv4_subnet, tags):
-    resource = cloudscale.network
-    _create(
-        resource=resource,
+    cloudscale.cmd_create(
         name=name,
         zone=zone,
         mtu=mtu,
         auto_create_ipv4_subnet=auto_create_ipv4_subnet,
         tags=tags,
-        )
+    )
 
 @click.argument('uuid', required=True)
 @click.option('--name')
@@ -64,9 +53,7 @@ def cmd_create(cloudscale, name, zone, mtu, auto_create_ipv4_subnet, tags):
 @network.command("update")
 @click.pass_obj
 def cmd_update(cloudscale, uuid, name, mtu, tags, clear_tags, clear_all_tags):
-    resource = cloudscale.network
-    _update(
-        resource=resource,
+    cloudscale.cmd_update(
         uuid=uuid,
         tags=tags,
         clear_tags=clear_tags,
@@ -80,10 +67,7 @@ def cmd_update(cloudscale, uuid, name, mtu, tags, clear_tags, clear_all_tags):
 @network.command("delete")
 @click.pass_obj
 def cmd_delete(cloudscale, uuid, force):
-    resource = cloudscale.network
-    _delete(
-        resource=resource,
+    cloudscale.cmd_delete(
         uuid=uuid,
-        headers=headers,
         force=force,
     )

--- a/cloudscale/commands/objects_user.py
+++ b/cloudscale/commands/objects_user.py
@@ -1,29 +1,20 @@
 import click
-from . import _init, _list, _show, _create, _update, _delete
-
-headers = ['display_name', 'id', 'tags']
 
 @click.group()
-@click.option('--api-token', '-a', envvar='CLOUDSCALE_API_TOKEN', help="API token.")
-@click.option('--profile', '-p', envvar='CLOUDSCALE_PROFILE', help="Profile used in config file.")
-@click.option('--verbose', '-v', is_flag=True, help='Enables verbose mode.')
 @click.pass_context
-def objects_user(ctx, profile, api_token, verbose):
-    _init(
-        ctx=ctx,
-        api_token=api_token,
-        profile=profile,
-        verbose=verbose,
-    )
+def objects_user(ctx):
+    ctx.obj.cloud_resource_name = "objects_user"
+    ctx.obj.headers = [
+        'display_name',
+        'id',
+        'tags',
+    ]
 
 @click.option('--filter-tag')
 @objects_user.command("list")
 @click.pass_obj
 def cmd_list(cloudscale, filter_tag):
-    resource = cloudscale.objects_user
-    _list(
-        resource=resource,
-        headers=headers,
+    cloudscale.cmd_list(
         filter_tag=filter_tag,
     )
 
@@ -31,9 +22,7 @@ def cmd_list(cloudscale, filter_tag):
 @objects_user.command("show")
 @click.pass_obj
 def cmd_show(cloudscale, uuid):
-    resource = cloudscale.objects_user
-    _show(
-        resource=resource,
+    cloudscale.cmd_show(
         uuid=uuid,
     )
 
@@ -42,9 +31,7 @@ def cmd_show(cloudscale, uuid):
 @objects_user.command("create")
 @click.pass_obj
 def cmd_create(cloudscale, display_name, tags):
-    resource = cloudscale.objects_user
-    _create(
-        resource=resource,
+    cloudscale.cmd_create(
         display_name=display_name,
         tags=tags
     )
@@ -57,9 +44,7 @@ def cmd_create(cloudscale, display_name, tags):
 @objects_user.command("update")
 @click.pass_obj
 def cmd_update(cloudscale, uuid, display_name, tags, clear_tags, clear_all_tags):
-    resource = cloudscale.objects_user
-    _update(
-        resource=resource,
+    cloudscale.cmd_update(
         uuid=uuid,
         tags=tags,
         clear_tags=clear_tags,
@@ -72,10 +57,7 @@ def cmd_update(cloudscale, uuid, display_name, tags, clear_tags, clear_all_tags)
 @objects_user.command("delete")
 @click.pass_obj
 def cmd_delete(cloudscale, uuid, force):
-    resource = cloudscale.objects_user
-    _delete(
-        resource=resource,
+    cloudscale.cmd_delete(
         uuid=uuid,
-        headers=headers,
         force=force,
     )

--- a/cloudscale/commands/region.py
+++ b/cloudscale/commands/region.py
@@ -1,29 +1,18 @@
-import sys
 import click
-from ..util import to_table
-from .. import Cloudscale, CloudscaleApiException, CloudscaleException
-from . import _init, _list
-
-headers = ['zones', 'slug']
 
 @click.group()
-@click.option('--api-token', '-a', envvar='CLOUDSCALE_API_TOKEN', help="API token.")
-@click.option('--profile', '-p', envvar='CLOUDSCALE_PROFILE', help="Profile used in config file.")
-@click.option('--verbose', '-v', is_flag=True, help='Enables verbose mode.')
 @click.pass_context
-def region(ctx, profile, api_token, verbose):
-    _init(
-        ctx=ctx,
-        api_token=api_token,
-        profile=profile,
-        verbose=verbose,
-    )
+def region(ctx):
+    ctx.obj.cloud_resource_name = "region"
+    ctx.obj.headers = [
+        'name',
+        'vcpu_count',
+        'memory_gb',
+        'slug',
+        'zones',
+    ]
 
 @region.command("list")
 @click.pass_obj
 def cmd_list(cloudscale):
-    resource = cloudscale.region
-    _list(
-        resource=resource,
-        headers=headers,
-    )
+    cloudscale.cmd_list()

--- a/cloudscale/commands/server.py
+++ b/cloudscale/commands/server.py
@@ -1,29 +1,25 @@
 import click
-from . import _init, _list, _show, _create, _update, _delete, _act
-
-headers = ['name', 'image', 'flavor', 'zone', 'tags', 'server_groups', 'uuid', 'status']
 
 @click.group()
-@click.option('--api-token', '-a', envvar='CLOUDSCALE_API_TOKEN', help="API token.")
-@click.option('--profile', '-p', envvar='CLOUDSCALE_PROFILE', help="Profile used in config file.")
-@click.option('--verbose', '-v', is_flag=True, help='Enables verbose mode.')
 @click.pass_context
-def server(ctx, profile, api_token, verbose):
-    _init(
-        ctx=ctx,
-        api_token=api_token,
-        profile=profile,
-        verbose=verbose,
-    )
+def server(ctx):
+    ctx.obj.cloud_resource_name = "server"
+    ctx.obj.headers = [
+        'name',
+        'image',
+        'flavor',
+        'zone',
+        'tags',
+        'server_groups',
+        'uuid',
+        'status',
+    ]
 
 @click.option('--filter-tag')
 @server.command("list")
 @click.pass_obj
 def cmd_list(cloudscale, filter_tag):
-    resource = cloudscale.server
-    _list(
-        resource=resource,
-        headers=headers,
+    cloudscale.cmd_list(
         filter_tag=filter_tag,
     )
 
@@ -31,9 +27,7 @@ def cmd_list(cloudscale, filter_tag):
 @server.command("show")
 @click.pass_obj
 def cmd_show(cloudscale, uuid):
-    resource = cloudscale.server
-    _show(
-        resource=resource,
+    cloudscale.cmd_show(
         uuid=uuid,
     )
 
@@ -72,9 +66,7 @@ def cmd_create(
     user_data,
     tags,
 ):
-    resource = cloudscale.server
-    _create(
-        resource=resource,
+    cloudscale.cmd_create(
         name=name,
         flavor=flavor,
         image=image,
@@ -102,9 +94,7 @@ def cmd_create(
 @server.command("update")
 @click.pass_obj
 def cmd_update(cloudscale, uuid, name, flavor, interfaces, tags, clear_tags, clear_all_tags):
-    resource = cloudscale.server
-    _update(
-        resource=resource,
+    cloudscale.cmd_update(
         uuid=uuid,
         tags=tags,
         clear_tags=clear_tags,
@@ -119,11 +109,8 @@ def cmd_update(cloudscale, uuid, name, flavor, interfaces, tags, clear_tags, cle
 @server.command("delete")
 @click.pass_obj
 def cmd_delete(cloudscale, uuid, force):
-    resource = cloudscale.server
-    _delete(
-        resource=resource,
+    cloudscale.cmd_delete(
         uuid=uuid,
-        headers=headers,
         force=force,
     )
 
@@ -131,9 +118,7 @@ def cmd_delete(cloudscale, uuid, force):
 @server.command("start")
 @click.pass_obj
 def cmd_start(cloudscale, uuid):
-    resource = cloudscale.server
-    _act(
-        resource=resource,
+    cloudscale.cmd_act(
         action="start",
         uuid=uuid,
     )
@@ -142,9 +127,7 @@ def cmd_start(cloudscale, uuid):
 @server.command("stop")
 @click.pass_obj
 def cmd_stop(cloudscale, uuid):
-    resource = cloudscale.server
-    _act(
-        resource=resource,
+    cloudscale.cmd_act(
         action="stop",
         uuid=uuid,
     )
@@ -153,9 +136,7 @@ def cmd_stop(cloudscale, uuid):
 @server.command("reboot")
 @click.pass_obj
 def cmd_reboot(cloudscale, uuid):
-    resource = cloudscale.server
-    _act(
-        resource=resource,
+    cloudscale.cmd_act(
         action="reboot",
         uuid=uuid,
     )

--- a/cloudscale/commands/server_group.py
+++ b/cloudscale/commands/server_group.py
@@ -1,29 +1,22 @@
 import click
-from . import _init, _list, _show, _create, _update, _delete
-
-headers = ['name', 'type', 'servers', 'tags', 'uuid']
 
 @click.group()
-@click.option('--api-token', '-a', envvar='CLOUDSCALE_API_TOKEN', help="API token.")
-@click.option('--profile', '-p', envvar='CLOUDSCALE_PROFILE', help="Profile used in config file.")
-@click.option('--verbose', '-v', is_flag=True, help='Enables verbose mode.')
 @click.pass_context
-def server_group(ctx, profile, api_token, verbose):
-    _init(
-        ctx=ctx,
-        api_token=api_token,
-        profile=profile,
-        verbose=verbose,
-    )
+def server_group(ctx):
+    ctx.obj.cloud_resource_name = "server_group"
+    ctx.obj.headers = [
+        'name',
+        'type',
+        'servers',
+        'tags',
+        'uuid',
+    ]
 
 @click.option('--filter-tag')
 @server_group.command("list")
 @click.pass_obj
 def cmd_list(cloudscale, filter_tag):
-    resource = cloudscale.server_group
-    _list(
-        resource=resource,
-        headers=headers,
+    cloudscale.cmd_list(
         filter_tag=filter_tag,
     )
 
@@ -31,9 +24,7 @@ def cmd_list(cloudscale, filter_tag):
 @server_group.command("show")
 @click.pass_obj
 def cmd_show(cloudscale, uuid):
-    resource = cloudscale.server_group
-    _show(
-        resource=resource,
+    cloudscale.cmd_show(
         uuid=uuid,
     )
 
@@ -43,9 +34,7 @@ def cmd_show(cloudscale, uuid):
 @server_group.command("create")
 @click.pass_obj
 def cmd_create(cloudscale, name, group_type, tags):
-    resource = cloudscale.server_group
-    _create(
-        resource=resource,
+    cloudscale.cmd_create(
         name=name,
         group_type=group_type,
         tags=tags,
@@ -59,9 +48,7 @@ def cmd_create(cloudscale, name, group_type, tags):
 @server_group.command("update")
 @click.pass_obj
 def cmd_update(cloudscale, uuid, name, tags, clear_tags, clear_all_tags):
-    resource = cloudscale.server_group
-    _update(
-        resource=resource,
+    cloudscale.cmd_update(
         uuid=uuid,
         tags=tags,
         clear_tags=clear_tags,
@@ -74,10 +61,7 @@ def cmd_update(cloudscale, uuid, name, tags, clear_tags, clear_all_tags):
 @server_group.command("delete")
 @click.pass_obj
 def cmd_delete(cloudscale, uuid, force):
-    resource = cloudscale.server_group
-    _delete(
-        resource=resource,
+    cloudscale.cmd_delete(
         uuid=uuid,
-        headers=headers,
         force=force,
     )

--- a/cloudscale/commands/subnet.py
+++ b/cloudscale/commands/subnet.py
@@ -1,29 +1,21 @@
 import click
-from . import _init, _list, _show, _create, _update, _delete
-
-headers = ['uuid', 'cidr', 'network', 'tags']
 
 @click.group()
-@click.option('--api-token', '-a', envvar='CLOUDSCALE_API_TOKEN', help="API token.")
-@click.option('--profile', '-p', envvar='CLOUDSCALE_PROFILE', help="Profile used in config file.")
-@click.option('--verbose', '-v', is_flag=True, help='Enables verbose mode.')
 @click.pass_context
-def subnet(ctx, profile, api_token, verbose):
-    _init(
-        ctx=ctx,
-        api_token=api_token,
-        profile=profile,
-        verbose=verbose,
-    )
+def subnet(ctx):
+    ctx.obj.cloud_resource_name = "subnet"
+    ctx.obj.headers = [
+        'uuid',
+        'cidr',
+        'network',
+        'tags',
+    ]
 
 @click.option('--filter-tag')
 @subnet.command("list")
 @click.pass_obj
 def cmd_list(cloudscale, filter_tag):
-    resource = cloudscale.subnet
-    _list(
-        resource=resource,
-        headers=headers,
+    cloudscale.cmd_list(
         filter_tag=filter_tag,
     )
 
@@ -31,8 +23,6 @@ def cmd_list(cloudscale, filter_tag):
 @subnet.command("show")
 @click.pass_obj
 def cmd_show(cloudscale, uuid):
-    resource = cloudscale.subnet
-    _show(
-        resource=resource,
+    cloudscale.cmd_show(
         uuid=uuid,
     )

--- a/cloudscale/commands/version.py
+++ b/cloudscale/commands/version.py
@@ -1,7 +1,0 @@
-import click
-from .. import APP_NAME
-from ..version import __version__
-
-@click.command("version")
-def cmd_version():
-    click.echo("%s %s" % (APP_NAME, __version__))

--- a/cloudscale/commands/volume.py
+++ b/cloudscale/commands/volume.py
@@ -1,40 +1,32 @@
 import click
-from . import _init, _list, _show, _create, _update, _delete
-
-headers = ['name', 'type', 'size_gb', 'zone', 'tags', 'server_uuids', 'uuid']
 
 @click.group()
-@click.option('--api-token', '-a', envvar='CLOUDSCALE_API_TOKEN', help="API token.")
-@click.option('--profile', '-p', envvar='CLOUDSCALE_PROFILE', help="Profile used in config file.")
-@click.option('--verbose', '-v', is_flag=True, help='Enables verbose mode.')
 @click.pass_context
-def volume(ctx, profile, api_token, verbose):
-    _init(
-        ctx=ctx,
-        api_token=api_token,
-        profile=profile,
-        verbose=verbose,
-    )
+def volume(ctx):
+    ctx.obj.cloud_resource_name = "volume"
+    ctx.obj.headers = [
+        'name',
+        'type',
+        'size_gb',
+        'zone',
+        'tags',
+        'server_uuids',
+        'uuid',
+    ]
 
 @click.option('--filter-tag')
 @volume.command("list")
 @click.pass_obj
 def cmd_list(cloudscale, filter_tag):
-    resource = cloudscale.volume
-    _list(
-        resource=resource,
-        headers=headers,
+    cloudscale.cmd_list(
         filter_tag=filter_tag,
     )
-
 
 @click.argument('uuid', required=True)
 @volume.command("show")
 @click.pass_obj
 def cmd_show(cloudscale, uuid):
-    resource = cloudscale.volume
-    _show(
-        resource=resource,
+    cloudscale.cmd_show(
         uuid=uuid,
     )
 
@@ -47,9 +39,7 @@ def cmd_show(cloudscale, uuid):
 @volume.command("create")
 @click.pass_obj
 def cmd_create(cloudscale, name, server_uuids, size_gb, volume_type, zone, tags):
-    resource = cloudscale.volume
-    _create(
-        resource=resource,
+    cloudscale.cmd_create(
         name=name,
         server_uuids=server_uuids,
         size_gb=size_gb,
@@ -68,9 +58,7 @@ def cmd_create(cloudscale, name, server_uuids, size_gb, volume_type, zone, tags)
 @volume.command("update")
 @click.pass_obj
 def cmd_update(cloudscale, uuid, name, server_uuids, size_gb, tags, clear_tags, clear_all_tags):
-    resource = cloudscale.volume
-    _update(
-        resource=resource,
+    cloudscale.cmd_update(
         uuid=uuid,
         tags=tags,
         clear_tags=clear_tags,
@@ -85,10 +73,7 @@ def cmd_update(cloudscale, uuid, name, server_uuids, size_gb, tags, clear_tags, 
 @volume.command("delete")
 @click.pass_obj
 def cmd_delete(cloudscale, uuid, force):
-    resource = cloudscale.volume
-    _delete(
-        resource=resource,
+    cloudscale.cmd_delete(
         uuid=uuid,
-        headers=headers,
         force=force,
     )

--- a/cloudscale/tests/test_flavor.py
+++ b/cloudscale/tests/test_flavor.py
@@ -44,16 +44,16 @@ def test_flavor_get_all():
 
     runner = CliRunner()
     result = runner.invoke(cli, [
-        'flavor',
         '-a',
         'token',
+        'flavor',
         'list',
     ])
     assert result.exit_code == 0
     result = runner.invoke(cli, [
-        'flavor',
         '-a',
         'token',
+        'flavor',
         'list',
     ])
     assert result.exit_code > 0

--- a/cloudscale/tests/test_floating_ip.py
+++ b/cloudscale/tests/test_floating_ip.py
@@ -47,16 +47,16 @@ def test_floating_ip_get_all():
 
     runner = CliRunner()
     result = runner.invoke(cli, [
-        'floating-ip',
         '-a',
         'token',
+        'floating-ip',
         'list',
     ])
     assert result.exit_code == 0
     result = runner.invoke(cli, [
-        'floating-ip',
         '-a',
         'token',
+        'floating-ip',
         'list',
     ])
     assert result.exit_code > 0
@@ -86,15 +86,15 @@ def test_floating_ip_get_by_uuid():
 
     runner = CliRunner()
     result = runner.invoke(cli, [
-        'floating-ip',
         '-a', 'token',
+        'floating-ip',
         'show',
         network_id,
     ])
     assert result.exit_code == 0
     result = runner.invoke(cli, [
-        'floating-ip',
         '-a', 'token',
+        'floating-ip',
         'show',
         network_id,
     ])
@@ -137,24 +137,24 @@ def test_floating_ip_delete():
 
     runner = CliRunner()
     result = runner.invoke(cli, [
-        'floating-ip',
         '-a', 'token',
+        'floating-ip',
         'delete',
         network_id,
     ])
     assert result.exit_code == 1
     runner = CliRunner()
     result = runner.invoke(cli, [
-        'floating-ip',
         '-a', 'token',
+        'floating-ip',
         'delete',
         network_id,
         '--force',
     ])
     assert result.exit_code == 0
     result = runner.invoke(cli, [
-        'floating-ip',
         '-a', 'token',
+        'floating-ip',
         'delete',
         '--force',
         'unknown',
@@ -187,8 +187,8 @@ def test_floating_ip_create():
     )
     runner = CliRunner()
     result = runner.invoke(cli, [
-        'floating-ip',
         '-a', 'token',
+        'floating-ip',
         'create',
         '--ip-version',
         ip_version,
@@ -197,8 +197,8 @@ def test_floating_ip_create():
     ])
     assert result.exit_code == 0
     result = runner.invoke(cli, [
-        'floating-ip',
         '-a', 'token',
+        'floating-ip',
         'create',
         '--ip-version',
         ip_version,
@@ -207,8 +207,8 @@ def test_floating_ip_create():
     ])
     assert result.exit_code > 0
     result = runner.invoke(cli, [
-        'floating-ip',
         '-a', 'token',
+        'floating-ip',
         'create',
         '--ip-version',
         6,
@@ -255,8 +255,8 @@ def test_floating_ip_update():
 
     runner = CliRunner()
     result = runner.invoke(cli, [
-        'floating-ip',
         '-a', 'token',
+        'floating-ip',
         'update',
         '--reverse-ptr',
         reverse_ptr,
@@ -264,8 +264,8 @@ def test_floating_ip_update():
     ])
     assert result.exit_code == 0
     result = runner.invoke(cli, [
-        'floating-ip',
         '-a', 'token',
+        'floating-ip',
         'update',
         '--reverse-ptr',
         reverse_ptr,

--- a/cloudscale/tests/test_image.py
+++ b/cloudscale/tests/test_image.py
@@ -44,16 +44,16 @@ def test_image_get_all():
 
     runner = CliRunner()
     result = runner.invoke(cli, [
-        'image',
         '-a',
         'token',
+        'image',
         'list',
     ])
     assert result.exit_code == 0
     result = runner.invoke(cli, [
-        'image',
         '-a',
         'token',
+        'image',
         'list',
     ])
     assert result.exit_code > 0

--- a/cloudscale/tests/test_network.py
+++ b/cloudscale/tests/test_network.py
@@ -48,16 +48,16 @@ def test_network_get_all():
 
     runner = CliRunner()
     result = runner.invoke(cli, [
-        'network',
         '-a',
         'token',
+        'network',
         'list',
     ])
     assert result.exit_code == 0
     result = runner.invoke(cli, [
-        'network',
         '-a',
         'token',
+        'network',
         'list',
     ])
     assert result.exit_code > 0
@@ -88,15 +88,15 @@ def test_network_get_by_uuid():
 
     runner = CliRunner()
     result = runner.invoke(cli, [
-        'network',
         '-a', 'token',
+        'network',
         'show',
         uuid,
     ])
     assert result.exit_code == 0
     result = runner.invoke(cli, [
-        'network',
         '-a', 'token',
+        'network',
         'show',
         uuid,
     ])
@@ -139,24 +139,24 @@ def test_network_delete():
 
     runner = CliRunner()
     result = runner.invoke(cli, [
-        'network',
         '-a', 'token',
+        'network',
         'delete',
         uuid,
     ])
     assert result.exit_code == 1
     runner = CliRunner()
     result = runner.invoke(cli, [
-        'network',
         '-a', 'token',
+        'network',
         'delete',
         uuid,
         '--force',
     ])
     assert result.exit_code == 0
     result = runner.invoke(cli, [
-        'network',
         '-a', 'token',
+        'network',
         'delete',
         '--force',
         'unknown',
@@ -190,16 +190,16 @@ def test_network_create():
 
     runner = CliRunner()
     result = runner.invoke(cli, [
-        'network',
         '-a', 'token',
+        'network',
         'create',
         '--name',
         name,
     ])
     assert result.exit_code == 0
     result = runner.invoke(cli, [
-        'network',
         '-a', 'token',
+        'network',
         'create',
         '--name',
         name,
@@ -244,8 +244,8 @@ def test_network_update():
 
     runner = CliRunner()
     result = runner.invoke(cli, [
-        'network',
         '-a', 'token',
+        'network',
         'update',
         uuid,
         '--name',
@@ -253,8 +253,8 @@ def test_network_update():
     ])
     assert result.exit_code == 0
     result = runner.invoke(cli, [
-        'network',
         '-a', 'token',
+        'network',
         'update',
         uuid,
         '--name',

--- a/cloudscale/tests/test_objects_user.py
+++ b/cloudscale/tests/test_objects_user.py
@@ -71,25 +71,25 @@ def test_objects_user_get_all():
 
     runner = CliRunner()
     result = runner.invoke(cli, [
-        'objects-user',
         '-a',
         'token',
+        'objects-user',
         'list',
     ])
     assert result.exit_code == 0
     result = runner.invoke(cli, [
-        'objects-user',
         '-a',
         'token',
+        'objects-user',
         'list',
         '--filter-tag',
         'project=apollo',
     ])
     assert result.exit_code == 0
     result = runner.invoke(cli, [
-        'objects-user',
         '-a',
         'token',
+        'objects-user',
         'list',
     ])
     assert result.exit_code > 0
@@ -121,16 +121,16 @@ def test_objects_user_get_by_uuid():
 
     runner = CliRunner()
     result = runner.invoke(cli, [
-        'objects-user',
         '-a', 'token',
+        'objects-user',
         'show',
         uuid,
     ])
     assert result.exit_code == 0
 
     result = runner.invoke(cli, [
-        'objects-user',
         '-a', 'token',
+        'objects-user',
         'show',
         'unknown',
     ])
@@ -171,23 +171,23 @@ def test_objects_user_delete():
 
     runner = CliRunner()
     result = runner.invoke(cli, [
-        'objects-user',
         '-a', 'token',
+        'objects-user',
         'delete',
         uuid,
     ])
     assert result.exit_code == 1
     result = runner.invoke(cli, [
-        'objects-user',
         '-a', 'token',
+        'objects-user',
         'delete',
         '--force',
         uuid,
     ])
     assert result.exit_code == 0
     result = runner.invoke(cli, [
-        'objects-user',
         '-a', 'token',
+        'objects-user',
         'delete',
         '--force',
         'unknown',
@@ -234,16 +234,16 @@ def test_objects_user_create():
 
     runner = CliRunner()
     result = runner.invoke(cli, [
-        'objects-user',
         '-a', 'token',
+        'objects-user',
         'create',
         '--display-name',
         display_name,
     ])
     assert result.exit_code == 0
     result = runner.invoke(cli, [
-        'objects-user',
         '-a', 'token',
+        'objects-user',
         'create',
         '--display-name',
         display_name,
@@ -289,8 +289,8 @@ def test_objects_user_update():
 
     runner = CliRunner()
     result = runner.invoke(cli, [
-        'objects-user',
         '-a', 'token',
+        'objects-user',
         'update',
         uuid,
         '--display-name',
@@ -298,8 +298,8 @@ def test_objects_user_update():
     ])
     assert result.exit_code == 0
     result = runner.invoke(cli, [
-        'objects-user',
         '-a', 'token',
+        'objects-user',
         'update',
         'unknown',
         '--display-name',

--- a/cloudscale/tests/test_region.py
+++ b/cloudscale/tests/test_region.py
@@ -37,16 +37,16 @@ def test_region_get_all():
 
     runner = CliRunner()
     result = runner.invoke(cli, [
-        'region',
         '-a',
         'token',
+        'region',
         'list',
     ])
     assert result.exit_code == 0
     result = runner.invoke(cli, [
-        'region',
         '-a',
         'token',
+        'region',
         'list',
     ])
     assert result.exit_code > 0

--- a/cloudscale/tests/test_server.py
+++ b/cloudscale/tests/test_server.py
@@ -52,16 +52,16 @@ def test_server_get_all():
 
     runner = CliRunner()
     result = runner.invoke(cli, [
-        'server',
         '-a',
         'token',
+        'server',
         'list',
     ])
     assert result.exit_code == 0
     result = runner.invoke(cli, [
-        'server',
         '-a',
         'token',
+        'server',
         'list',
     ])
     assert result.exit_code > 0
@@ -82,18 +82,18 @@ def test_server_get_all_fitlered():
 
     runner = CliRunner()
     result = runner.invoke(cli, [
-        'server',
         '-a',
         'token',
+        'server',
         'list',
         '--filter-tag',
         'project=gemini'
     ])
     assert result.exit_code == 0
     result = runner.invoke(cli, [
-        'server',
         '-a',
         'token',
+        'server',
         'list',
         '--filter-tag',
         'project'
@@ -129,15 +129,15 @@ def test_server_get_by_uuid():
 
     runner = CliRunner()
     result = runner.invoke(cli, [
-        'server',
         '-a', 'token',
+        'server',
         'show',
         uuid,
     ])
     assert result.exit_code == 0
     result = runner.invoke(cli, [
-        'server',
         '-a', 'token',
+        'server',
         'show',
         uuid,
     ])
@@ -180,24 +180,24 @@ def test_server_delete():
 
     runner = CliRunner()
     result = runner.invoke(cli, [
-        'server',
         '-a', 'token',
+        'server',
         'delete',
         uuid,
     ])
     assert result.exit_code == 1
     runner = CliRunner()
     result = runner.invoke(cli, [
-        'server',
         '-a', 'token',
+        'server',
         'delete',
         '--force',
         uuid,
     ])
     assert result.exit_code == 0
     result = runner.invoke(cli, [
-        'server',
         '-a', 'token',
+        'server',
         'delete',
         '--force',
         'unknown',
@@ -261,8 +261,8 @@ def test_server_create():
 
     runner = CliRunner()
     result = runner.invoke(cli, [
-        'server',
         '-a', 'token',
+        'server',
         'create',
         '--name',
         name,
@@ -273,8 +273,8 @@ def test_server_create():
     ])
     assert result.exit_code == 0
     result = runner.invoke(cli, [
-        'server',
         '-a', 'token',
+        'server',
         'create',
         '--name',
         name,
@@ -325,8 +325,8 @@ def test_server_update():
 
     runner = CliRunner()
     result = runner.invoke(cli, [
-        'server',
         '-a', 'token',
+        'server',
         'update',
         '--name',
         name,
@@ -336,8 +336,8 @@ def test_server_update():
     ])
     assert result.exit_code == 0
     result = runner.invoke(cli, [
-        'server',
         '-a', 'token',
+        'server',
         'update',
         '--name',
         name,
@@ -382,15 +382,15 @@ def test_server_start():
 
     runner = CliRunner()
     result = runner.invoke(cli, [
-        'server',
         '-a', 'token',
+        'server',
         'start',
         uuid,
     ])
     assert result.exit_code == 0
     result = runner.invoke(cli, [
-        'server',
         '-a', 'token',
+        'server',
         'start',
         uuid,
     ])
@@ -431,15 +431,15 @@ def test_server_stop():
 
     runner = CliRunner()
     result = runner.invoke(cli, [
-        'server',
         '-a', 'token',
+        'server',
         'stop',
         uuid,
     ])
     assert result.exit_code == 0
     result = runner.invoke(cli, [
-        'server',
         '-a', 'token',
+        'server',
         'stop',
         uuid,
     ])
@@ -480,15 +480,15 @@ def test_server_reboot():
 
     runner = CliRunner()
     result = runner.invoke(cli, [
-        'server',
         '-a', 'token',
+        'server',
         'reboot',
         uuid,
     ])
     assert result.exit_code == 0
     result = runner.invoke(cli, [
-        'server',
         '-a', 'token',
+        'server',
         'reboot',
         uuid,
     ])

--- a/cloudscale/tests/test_server_group.py
+++ b/cloudscale/tests/test_server_group.py
@@ -52,16 +52,18 @@ def test_server_groups_get_all():
 
     runner = CliRunner()
     result = runner.invoke(cli, [
-        'server-group',
         '-a',
         'token',
+        'server-group',
         'list',
     ])
     assert result.exit_code == 0
     result = runner.invoke(cli, [
-        'server-group',
         '-a',
         'token',
+        '-o',
+        'json',
+        'server-group',
         'list',
     ])
     assert result.exit_code > 0
@@ -92,15 +94,16 @@ def test_server_groups_get_by_uuid():
 
     runner = CliRunner()
     result = runner.invoke(cli, [
-        'server-group',
         '-a', 'token',
+        'server-group',
         'show',
         uuid,
     ])
     assert result.exit_code == 0
     result = runner.invoke(cli, [
-        'server-group',
         '-a', 'token',
+        '-o', 'json',
+        'server-group',
         'show',
         uuid,
     ])
@@ -143,23 +146,23 @@ def test_server_groups_delete():
 
     runner = CliRunner()
     result = runner.invoke(cli, [
-        'server-group',
         '-a', 'token',
+        'server-group',
         'delete',
         uuid,
     ])
     assert result.exit_code == 1
     result = runner.invoke(cli, [
-        'server-group',
         '-a', 'token',
+        'server-group',
         'delete',
         '--force',
         uuid,
     ])
     assert result.exit_code == 0
     result = runner.invoke(cli, [
-        'server-group',
         '-a', 'token',
+        'server-group',
         'delete',
         '--force',
         'unknown',
@@ -191,16 +194,16 @@ def test_server_groups_create():
     )
     runner = CliRunner()
     result = runner.invoke(cli, [
-        'server-group',
         '-a', 'token',
+        'server-group',
         'create',
         '--name',
         name,
     ])
     assert result.exit_code == 0
     result = runner.invoke(cli, [
-        'server-group',
         '-a', 'token',
+        'server-group',
         'create',
         '--name',
         name,
@@ -243,8 +246,8 @@ def test_server_groups_update():
 
     runner = CliRunner()
     result = runner.invoke(cli, [
-        'server-group',
         '-a', 'token',
+        'server-group',
         'update',
         '--name',
         name,
@@ -252,8 +255,8 @@ def test_server_groups_update():
     ])
     assert result.exit_code == 0
     result = runner.invoke(cli, [
-        'server-group',
         '-a', 'token',
+        'server-group',
         'update',
         '--name',
         name,
@@ -299,8 +302,8 @@ def test_invalid_tags_create():
 
     runner = CliRunner()
     result = runner.invoke(cli, [
-        'server-group',
         '-a', 'token',
+        'server-group',
         'create',
         '--name',
         name,
@@ -311,8 +314,8 @@ def test_invalid_tags_create():
 
     runner = CliRunner()
     result = runner.invoke(cli, [
-        'server-group',
         '-a', 'token',
+        'server-group',
         'create',
         '--name',
         name,
@@ -323,8 +326,8 @@ def test_invalid_tags_create():
 
     runner = CliRunner()
     result = runner.invoke(cli, [
-        'server-group',
         '-a', 'token',
+        'server-group',
         'create',
         '--name',
         name,
@@ -351,8 +354,8 @@ def test_invalid_tags_update():
 
     runner = CliRunner()
     result = runner.invoke(cli, [
-        'server-group',
         '-a', 'token',
+        'server-group',
         'update',
         '--name',
         name,
@@ -364,8 +367,8 @@ def test_invalid_tags_update():
 
     runner = CliRunner()
     result = runner.invoke(cli, [
-        'server-group',
         '-a', 'token',
+        'server-group',
         'update',
         '--name',
         name,
@@ -377,8 +380,8 @@ def test_invalid_tags_update():
 
     runner = CliRunner()
     result = runner.invoke(cli, [
-        'server-group',
         '-a', 'token',
+        'server-group',
         'update',
         '--name',
         name,

--- a/cloudscale/tests/test_subnet.py
+++ b/cloudscale/tests/test_subnet.py
@@ -41,16 +41,16 @@ def test_subnet_get_all():
 
     runner = CliRunner()
     result = runner.invoke(cli, [
-        'subnet',
         '-a',
         'token',
+        'subnet',
         'list',
     ])
     assert result.exit_code == 0
     result = runner.invoke(cli, [
-        'subnet',
         '-a',
         'token',
+        'subnet',
         'list',
     ])
     assert result.exit_code > 0
@@ -80,15 +80,15 @@ def test_subnet_get_by_uuid():
 
     runner = CliRunner()
     result = runner.invoke(cli, [
-        'subnet',
         '-a', 'token',
+        'subnet',
         'show',
         uuid,
     ])
     assert result.exit_code == 0
     result = runner.invoke(cli, [
-        'subnet',
         '-a', 'token',
+        'subnet',
         'show',
         uuid,
     ])

--- a/cloudscale/tests/test_version.py
+++ b/cloudscale/tests/test_version.py
@@ -7,6 +7,6 @@ def test_version():
 
     runner = CliRunner()
     result = runner.invoke(cli, [
-        'version',
+        '--version',
     ])
     assert result.exit_code == 0

--- a/cloudscale/tests/test_volume.py
+++ b/cloudscale/tests/test_volume.py
@@ -45,16 +45,16 @@ def test_volume_get_all():
 
     runner = CliRunner()
     result = runner.invoke(cli, [
-        'volume',
         '-a',
         'token',
+        'volume',
         'list',
     ])
     assert result.exit_code == 0
     result = runner.invoke(cli, [
-        'volume',
         '-a',
         'token',
+        'volume',
         'list',
     ])
     assert result.exit_code > 0
@@ -86,15 +86,15 @@ def test_volume_get_by_uuid():
 
     runner = CliRunner()
     result = runner.invoke(cli, [
-        'volume',
         '-a', 'token',
+        'volume',
         'show',
         uuid,
     ])
     assert result.exit_code == 0
     result = runner.invoke(cli, [
-        'volume',
         '-a', 'token',
+        'volume',
         'show',
         uuid,
     ])
@@ -137,23 +137,23 @@ def test_volume_delete():
 
     runner = CliRunner()
     result = runner.invoke(cli, [
-        'volume',
         '-a', 'token',
+        'volume',
         'delete',
         uuid,
     ])
     assert result.exit_code == 1
     result = runner.invoke(cli, [
-        'volume',
         '-a', 'token',
+        'volume',
         'delete',
         '--force',
         uuid,
     ])
     assert result.exit_code == 0
     result = runner.invoke(cli, [
-        'volume',
         '-a', 'token',
+        'volume',
         'delete',
         '--force',
         'unknown',
@@ -190,8 +190,8 @@ def test_volume_create():
     )
     runner = CliRunner()
     result = runner.invoke(cli, [
-        'volume',
         '-a', 'token',
+        'volume',
         'create',
         '--name',
         name,
@@ -202,8 +202,8 @@ def test_volume_create():
     ])
     assert result.exit_code == 0
     result = runner.invoke(cli, [
-        'volume',
         '-a', 'token',
+        'volume',
         'create',
         '--name',
         name,
@@ -251,8 +251,8 @@ def test_volume_update():
 
     runner = CliRunner()
     result = runner.invoke(cli, [
-        'volume',
         '-a', 'token',
+        'volume',
         'update',
         '--name',
         name,
@@ -260,8 +260,8 @@ def test_volume_update():
     ])
     assert result.exit_code == 0
     result = runner.invoke(cli, [
-        'volume',
         '-a', 'token',
+        'volume',
         'update',
         '--name',
         name,

--- a/cloudscale/util.py
+++ b/cloudscale/util.py
@@ -1,4 +1,3 @@
-
 import json
 from click import Group
 from collections import OrderedDict
@@ -28,29 +27,35 @@ def to_table(data: list, headers: list) -> str:
     for d in data:
         rows = list()
         for header in headers:
-            if header in d:
-                if header == 'tags':
-                    row = ', '.join(['%s=%s' % (k, v) for k, v in d[header].items()])
-                elif isinstance(d[header], dict):
-                    if 'name' in d[header]:
-                        row = d[header]['name']
-                    elif 'slug' in d[header]:
-                        row = d[header]['slug']
-                elif isinstance(d[header], list):
-                    row_list = []
-                    for i in d[header]:
-                        if isinstance(i, dict):
-                            if 'slug' in i:
-                                row_list.append(i['slug'])
-                            elif 'name' in i:
-                                row_list.append(i['name'])
-                        else:
-                            row_list.append(i)
+            if header not in d:
+                continue
 
-                    row = ', '.join(row_list)
-                else:
-                    row = d[header]
-                rows.append(row)
+            if header == 'tags':
+                row = ', '.join(['%s=%s' % (k, v) for k, v in d[header].items()])
+
+            elif isinstance(d[header], dict):
+                if 'name' in d[header]:
+                    row = d[header]['name']
+                elif 'slug' in d[header]:
+                    row = d[header]['slug']
+
+            elif isinstance(d[header], list):
+                row_list = []
+                for i in d[header]:
+                    if isinstance(i, dict):
+                        if 'slug' in i:
+                            row_list.append(i['slug'])
+                        elif 'name' in i:
+                            row_list.append(i['name'])
+                    else:
+                        row_list.append(i)
+
+                row = ', '.join(row_list)
+
+            else:
+                row = d[header]
+
+            rows.append(row)
         cols.append(rows)
 
     result = tabulate(cols, headers=headers)


### PR DESCRIPTION
In this PR I move the common options such as `--api-token` to the cli group, as a consequence the CLI syntax slightly change from 

`cloudscale-cli server ---api-token <token> create ...`
to 
`cloudscale-cli --api-token <token> server create` 

which actually makes a lot more "sense" because, these options are not specific to the server resource.

Further the `version` options is removed and replaced by click internal version option but had to change it to`--version` arg (I tried it with `version` but click is not happy).

A refactoring was done in `commands,_init__` where I moved the functions to a new `CloudscaleCommand` wrapper class. This allowed to easily implement the `--output` option and I did it along (but I have some ideas to make it more generic and add probably add yaml and toml output.)

With the refactoring in place, the command group files become very slick, only a resource name for the attribute in the cloudscale lib `cloudscale.<resource_name>` is necessary and some headers for the table output.

~~~python
import click

@click.group()
@click.pass_context
def flavor(ctx):
    ctx.obj.cloud_resource_name = "flavor"
    ctx.obj.headers = [
        'name',
        'vcpu_count',
        'memory_gb',
        'slug',
        'zones',
    ]

@flavor.command("list")
@click.pass_obj
def cmd_list(cloudscale):
    cloudscale.cmd_list()
 ~~~

Test coverage is 99% (seems the github actions don't run, cloud you check, I don't have access). 